### PR TITLE
Add Common Lisp, Scheme, Racket, Clojure

### DIFF
--- a/plugin/name-assign.vim
+++ b/plugin/name-assign.vim
@@ -33,6 +33,22 @@ let g:name_assign_filetypes = {
   \    "go": {
   \        "prefix" : "%s := ",
   \    },
+  \    "lisp": {
+  \        "prefix" : "(let ((%s ",
+  \        "suffix" : ")))",
+  \    },
+  \    "scheme": {
+  \        "prefix" : "(let ((%s ",
+  \        "suffix" : ")))",
+  \    },
+  \    "racket": {
+  \        "prefix" : "(let ([%s ",
+  \        "suffix" : "]))",
+  \    },
+  \    "clojure": {
+  \        "prefix" : "(let [%s ",
+  \        "suffix" : "])",
+  \    },
   \}
 
 let s:maps_defaults = {


### PR DESCRIPTION
These aren't great because `let` bindings are scoped only within the outermost parenthesis, but any self-respecting lisp programmer will be using a [plugin](https://github.com/guns/vim-sexp) to handle that easily.