### PR TITLE
Add Support for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There can be any amount of lines between the top expression and the variable
 assignment.
 
 The plugin supports the following languages: Rust, C, C++, Go, VimScript,
-JavaScript, Python, LISP, Scheme, Racket, Clojure, Erlang, Elixir, Haskell and
+JavaScript, TypeScript, Python, LISP, Scheme, Racket, Clojure, Erlang, Elixir, Haskell and
 PureScript.
 
 

--- a/plugin/name-assign.vim
+++ b/plugin/name-assign.vim
@@ -28,6 +28,14 @@ let g:name_assign_filetypes = {
   \        "prefix" : "let %s = ",
   \        "suffix" : ";",
   \    },
+  \    "typescript": {
+  \        "prefix" : "let %s = ",
+  \        "suffix" : ";",
+  \    },
+  \    "typescriptreact": {
+  \        "prefix" : "let %s = ",
+  \        "suffix" : ";",
+  \    },
   \    "vim": {
   \        "prefix" : "let %s = ",
   \    },


### PR DESCRIPTION
This adds TypeScript/TypeScript(react) settings.
I thought `const` is another choice to declare variables in TypeScript, which I usually prefer, but have chosen `let` to keep consistency with existing JavaScript setting.